### PR TITLE
Add salted password storage for user accounts

### DIFF
--- a/Poke/Assets/Scripts/Network/NetworkManager.cs
+++ b/Poke/Assets/Scripts/Network/NetworkManager.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using System;
 using System.Collections.Generic;
+using System.Security.Cryptography;
 
 /// <summary>
 /// Mock server-side storage.
@@ -10,7 +11,24 @@ public class NetworkManager : MonoBehaviour
 {
     public static NetworkManager Instance { get; private set; }
 
-    private Dictionary<string, string> registeredUsers = new Dictionary<string, string>();
+    private class UserRecord
+    {
+        public string Email { get; }
+        public byte[] Salt { get; }
+        public byte[] PasswordHash { get; }
+
+        public UserRecord(string email, byte[] salt, byte[] passwordHash)
+        {
+            Email = email;
+            Salt = salt;
+            PasswordHash = passwordHash;
+        }
+    }
+
+    private Dictionary<string, UserRecord> registeredUsers = new Dictionary<string, UserRecord>();
+    private const int SaltSize = 16;
+    private const int HashSize = 32;
+    private const int HashIterations = 10000;
     private Dictionary<string, CharacterData> characterDatabase = new Dictionary<string, CharacterData>();
 
     private void Awake()
@@ -28,7 +46,20 @@ public class NetworkManager : MonoBehaviour
 
     public void SendLoginRequest(string username, string password, Action<bool, string> callback)
     {
-        if (registeredUsers.ContainsKey(username) && registeredUsers[username] == password)
+        if (string.IsNullOrWhiteSpace(username) || string.IsNullOrWhiteSpace(password))
+        {
+            callback?.Invoke(false, "Username and password are required.");
+            return;
+        }
+
+        if (!registeredUsers.TryGetValue(username, out var record))
+        {
+            callback?.Invoke(false, "Invalid username or password.");
+            return;
+        }
+
+        var hashedPassword = HashPassword(password, record.Salt);
+        if (AreHashesEqual(hashedPassword, record.PasswordHash))
         {
             callback?.Invoke(true, username);
         }
@@ -40,14 +71,57 @@ public class NetworkManager : MonoBehaviour
 
     public void SendRegisterRequest(string username, string password, string email, Action<bool, string> callback)
     {
+        if (string.IsNullOrWhiteSpace(username) || string.IsNullOrWhiteSpace(password) || string.IsNullOrWhiteSpace(email))
+        {
+            callback?.Invoke(false, "Username, password, and email are required.");
+            return;
+        }
+
         if (registeredUsers.ContainsKey(username))
         {
             callback?.Invoke(false, "Username already exists.");
             return;
         }
 
-        registeredUsers[username] = password;
+        var salt = GenerateSalt();
+        var passwordHash = HashPassword(password, salt);
+        registeredUsers[username] = new UserRecord(email, salt, passwordHash);
         callback?.Invoke(true, $"Account '{username}' registered successfully.");
+    }
+
+    private static byte[] GenerateSalt()
+    {
+        var salt = new byte[SaltSize];
+        using (var rng = RandomNumberGenerator.Create())
+        {
+            rng.GetBytes(salt);
+        }
+
+        return salt;
+    }
+
+    private static byte[] HashPassword(string password, byte[] salt)
+    {
+        using (var deriveBytes = new Rfc2898DeriveBytes(password, salt, HashIterations, HashAlgorithmName.SHA256))
+        {
+            return deriveBytes.GetBytes(HashSize);
+        }
+    }
+
+    private static bool AreHashesEqual(byte[] left, byte[] right)
+    {
+        if (left == null || right == null || left.Length != right.Length)
+        {
+            return false;
+        }
+
+        var result = 0;
+        for (var i = 0; i < left.Length; i++)
+        {
+            result |= left[i] ^ right[i];
+        }
+
+        return result == 0;
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- introduce a user record structure to store account email, salt, and hashed password
- update registration and login to validate input and hash passwords with PBKDF2 before storage and comparison

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d593938f9083238b1b46276dc4c1aa