### PR TITLE
Track characters per owner

### DIFF
--- a/Poke/Assets/Scripts/Account/CharacterCreator.cs
+++ b/Poke/Assets/Scripts/Account/CharacterCreator.cs
@@ -29,8 +29,23 @@ public class CharacterCreator : MonoBehaviour
             return;
         }
 
+        var accountManager = AccountManager.Instance;
+        if (accountManager == null)
+        {
+            Debug.LogError("AccountManager instance is not available. Cannot create character.");
+            return;
+        }
+
+        string ownerUsername = accountManager.GetLoggedInUser();
+        if (string.IsNullOrEmpty(ownerUsername))
+        {
+            Debug.LogError("No user is currently logged in. Cannot create character.");
+            return;
+        }
+
         CharacterData newChar = new CharacterData
         {
+            ownerUsername = ownerUsername,
             characterName = name,
             race = race,
             gender = gender,

--- a/Poke/Assets/Scripts/Account/CharacterData.cs
+++ b/Poke/Assets/Scripts/Account/CharacterData.cs
@@ -6,6 +6,7 @@ public enum PlayerGender { Male, Female, NonBinary }
 [System.Serializable]
 public class CharacterData
 {
+    public string ownerUsername;
     public string characterName;
     public PlayerRace race;
     public PlayerGender gender;

--- a/Poke/Assets/Scripts/Network/NetworkManager.cs
+++ b/Poke/Assets/Scripts/Network/NetworkManager.cs
@@ -11,7 +11,7 @@ public class NetworkManager : MonoBehaviour
     public static NetworkManager Instance { get; private set; }
 
     private Dictionary<string, string> registeredUsers = new Dictionary<string, string>();
-    private Dictionary<string, CharacterData> characterDatabase = new Dictionary<string, CharacterData>();
+    private Dictionary<string, List<CharacterData>> characterDatabase = new Dictionary<string, List<CharacterData>>();
 
     private void Awake()
     {
@@ -56,19 +56,57 @@ public class NetworkManager : MonoBehaviour
 
     public void SendCharacterCreationRequest(CharacterData data)
     {
-        if (characterDatabase.ContainsKey(data.characterName))
+        if (data == null)
+        {
+            Debug.LogError("Character data cannot be null.");
+            return;
+        }
+
+        if (string.IsNullOrEmpty(data.ownerUsername))
+        {
+            Debug.LogError("Character must have a valid owner before creation.");
+            return;
+        }
+
+        if (!characterDatabase.ContainsKey(data.ownerUsername))
+        {
+            characterDatabase[data.ownerUsername] = new List<CharacterData>();
+        }
+
+        List<CharacterData> ownerCharacters = characterDatabase[data.ownerUsername];
+
+        if (ownerCharacters.Exists(c => c.characterName == data.characterName))
         {
             Debug.LogError("Character name already exists!");
             return;
         }
 
-        characterDatabase[data.characterName] = data;
+        ownerCharacters.Add(data);
         Debug.Log($"[NetworkManager] Character '{data.characterName}' created.");
     }
 
     public List<CharacterData> GetAllCharacters()
     {
-        return new List<CharacterData>(characterDatabase.Values);
+        var accountManager = AccountManager.Instance;
+        if (accountManager == null)
+        {
+            Debug.LogError("AccountManager instance is not available. Cannot fetch characters.");
+            return new List<CharacterData>();
+        }
+
+        string ownerUsername = accountManager.GetLoggedInUser();
+        if (string.IsNullOrEmpty(ownerUsername))
+        {
+            Debug.LogWarning("No user is currently logged in. Returning empty character list.");
+            return new List<CharacterData>();
+        }
+
+        if (!characterDatabase.TryGetValue(ownerUsername, out List<CharacterData> ownerCharacters))
+        {
+            return new List<CharacterData>();
+        }
+
+        return new List<CharacterData>(ownerCharacters);
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- add an ownerUsername field to CharacterData
- require a logged-in user before creating characters and populate the owner name
- store characters per-account on the NetworkManager and filter queries by the active user

## Testing
- not run (unity project)

------
https://chatgpt.com/codex/tasks/task_e_68d5938ec01c8323a732a42969f163a4